### PR TITLE
Makefile: Don't hard-code `bash` path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Copyright Alan K. Stebbens <aks@stebbens.org>
 
-SHELL = /usr/local/bin/bash
+SHELL := $(shell which bash)
 bindirs =
 bins =
 


### PR DESCRIPTION
Path to `bash` is hard-coded in the Makefile leading to the issue #10. Fix by calling `which` to determine the actual location.